### PR TITLE
Cleanup and expand wheel job definitions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,11 +10,6 @@ on:
     types:
       - published
 
-env:
-  CIBW_TEST_COMMAND: pytest {project}/tests
-  CIBW_TEST_EXTRAS: test
-
-
 jobs:
   build_sdist:
     name: Build SDist
@@ -23,17 +18,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-
     - name: Build SDist
       run: pipx run build --sdist
-
     - name: Check metadata
       run: pipx run twine check dist/*
-
     - uses: actions/upload-artifact@v2
       with:
         path: dist/*.tar.gz
-
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}
@@ -42,40 +33,149 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
-
     - uses: pypa/cibuildwheel@v2.3.1
-      env:
-        CIBW_TEST_REQUIRES: qiskit-terra>=0.19.0
-
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash
-
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:
         path: wheelhouse/*.whl
 
+  build_wheels_arm64_macos:
+    name: Wheels on ${{ matrix.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: pypa/cibuildwheel@v2.3.1
+      env:
+        CIBW_ARCHS_MACOS: arm64
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+
+  build_wheels_arm64_linux:
+    name: Wheels on ${{ matrix.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+    - uses: pypa/cibuildwheel@v2.3.1
+      env:
+        CIBW_ARCHS_LINUX: arm64
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        packages_dir: wheelhouse/
+
+  build_wheels_ppc64le_linux:
+    name: Wheels on ${{ matrix.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+    - uses: pypa/cibuildwheel@v2.3.1
+      env:
+        CIBW_ARCHS_LINUX: ppc64le
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        packages_dir: wheelhouse/
+
+  build_wheels_s390x_linux:
+    name: Wheels on ${{ matrix.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+    - uses: pypa/cibuildwheel@v2.3.1
+      env:
+        CIBW_ARCHS_LINUX: ppc64le
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*.whl
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+        packages_dir: wheelhouse/
 
   upload_all:
     name: Upload if release
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
-
     steps:
     - uses: actions/setup-python@v2
-
     - uses: actions/download-artifact@v2
       with:
         name: artifact
         path: dist
-
     - uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
+
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+test-requires = ["qiskit-terra>=0.19"]
+skip = "pp* cp36-* *musllinux*"
+test-command = "pytest {project}/tests"
+test-extras = ["test"]


### PR DESCRIPTION
This commit makes a few small changes to the cibuildwheel ci job
definitions. The first change it makes is to unify the job configuration
to a single location in the pyproject.toml. In recent versions of
cibuildwheel you can set the configuration in the pyproject.toml (or
optionally a different toml file) to have a unified config for all jobs.
This makes it simpler to maintain as we can have a common config and
then per job overrides as needed. As part of this several rough edges in
the config are changed mainly around supported environments so we only
build in environments that qiskit currently supports. The second change
here is to expand the build matrix to enable cross-builds for other CPU
architectures. This is mainly arm64/aarch64 on Linux and macOS, pp64le
on linux, and s390x on linux. Since we don't have native hardware
available to compile on these platforms in CI we either leverage cross
compilation (on macos arm64) or qemu emulation. However as emulation is
painfully slow, or in the case of cross builds the binaries are
untestable these jobs are reserved just for release time as we don't
want this overhead during normal commits.