### PR TITLE
Account for distance between indirect neighbors.

### DIFF
--- a/src/qiskit_toqm/toqm_swap.py
+++ b/src/qiskit_toqm/toqm_swap.py
@@ -134,13 +134,21 @@ class ToqmSwap(TransformationPass):
             return max_duration
 
         start_dur = 0
+        last_dur = 0
         smallest_diff = float('inf')
         for dur in durations_asc:
-            diff = dur - start_dur
-            if diff < smallest_allowed:
+            cur_diff = dur - last_dur
+            running_diff = dur - start_dur
+            last_dur = dur
+
+            if running_diff < smallest_allowed:
+                # both cur_diff and running_diff are too small, keep going!
                 continue
+
+            diff = cur_diff if cur_diff >= smallest_allowed else running_diff
             if diff < smallest_diff:
                 smallest_diff = diff
+
             start_dur = dur
 
         # ceil to mitigate FP rounding error.

--- a/test/qiskit_toqm/test_toqm_swap.py
+++ b/test/qiskit_toqm/test_toqm_swap.py
@@ -3,6 +3,8 @@ import unittest
 from qiskit_toqm.toqm_swap import ToqmSwap
 
 from qiskit.transpiler import TranspilerError
+from math import ceil
+from numpy import interp
 
 
 class TestCalcCycleMax(unittest.TestCase):
@@ -51,8 +53,47 @@ class TestCalcCycleMax(unittest.TestCase):
         )
 
     def test_capped_max(self):
-        durations = [i for i in range(100)]
+        durations = [i for i in range(101)]
         self.assertEqual(
             ToqmSwap._calc_cycle_max(durations, 50),
             50
         )
+
+    def test_capped_max_3(self):
+        """
+        Test that duration from 0 can be used as the smallest difference.
+        In this test, the smallest diff (between 1 and 3) is too small
+        :return:
+        """
+        durations = [1, 3, 61]
+
+        res = ToqmSwap._calc_cycle_max(durations, 60)
+        mapped_to_limit = [ceil(x) for x in interp(durations, [0, durations[-1]], [0, 60])]
+        mapped_to_act = [ceil(x) for x in interp(durations, [0, durations[-1]], [0, res])]
+
+        self.assertEqual(
+            ToqmSwap._calc_cycle_max(durations, 60),
+            31
+        )
+
+    def test_capped_max_2(self):
+        diffs = [
+            5.555e-10,
+            5.
+        ]
+        durations = [
+            3.5555555555555554e-08,
+            2.2755555555555555e-07,
+            2.7e-07,
+            2.702222222222222e-07,
+            3.0577777777777775e-07,
+            4.622222222222222e-07,
+            4.977777777777778e-07,
+        ]
+
+        cap = 1000
+        res = ToqmSwap._calc_cycle_max(durations, cap)
+
+        from numpy import interp
+        temp = [ceil(x) for x in interp(durations, [0, durations[-1]], [0, res])]
+        temp2 = [ceil(x) for x in interp(durations, [0, durations[-1]], [0, cap])]


### PR DESCRIPTION
Fix an issue with the original max cycle calculation where distances between indirect neighbors weren't considered.

The tests here aren't complete, but that's mostly because I'm considering changing the approach to be something simpler in a future changeset.