### PR TITLE
Use Latency126 for heuristic mappers.

### DIFF
--- a/src/qiskit_toqm/toqm_strategy.py
+++ b/src/qiskit_toqm/toqm_strategy.py
@@ -71,12 +71,16 @@ class ToqmStrategy:
             -1 if self.perform_layout else 0
         )
 
+    # NOTE: currently, the heuristic mapper uses the hard-coded latencies of 1, 2 and 6
+    # for 1Q, 2Q and SWAP gates, respectively. This is because when gate-specific latencies
+    # are used with heuristic components, the run sometimes never terminates.
+    # This is tracked here: https://github.com/qiskit-toqm/libtoqm/issues/15
     def _default_heuristic_mapper(self, max_nodes, min_nodes, k):
         mapper = toqm.ToqmMapper(
             toqm.TrimSlowNodes(max_nodes, min_nodes),
             toqm.GreedyTopK(k),
             toqm.CXFrontier(),
-            toqm.Table(self.latency_descriptions),
+            toqm.Latency_1_2_6(),
             [toqm.GreedyMapper()],
             [],
             -1 if self.perform_layout else 0
@@ -123,13 +127,13 @@ class ToqmStrategyO2(ToqmStrategy):
         if self.coupling_map.numPhysicalQubits < self.threshold:
             mapper = self._default_optimal_mapper()
         else:
-            mapper = self._default_heuristic_mapper(3000, 2000, 10)
+            mapper = self._default_heuristic_mapper(3000, 1200, 10)
 
         return mapper.run(gates, num_qubits, self.coupling_map)
 
 
 class ToqmStrategyO3(ToqmStrategy):
-    def __init__(self, optimality_threshold=7):
+    def __init__(self, optimality_threshold=6):
         """
         Initializer.
 
@@ -148,6 +152,6 @@ class ToqmStrategyO3(ToqmStrategy):
             except RuntimeError:
                 mapper = self._default_optimal_mapper()
         else:
-            mapper = self._default_heuristic_mapper(4000, 3000, 15)
+            mapper = self._default_heuristic_mapper(4500, 1200, 10)
 
         return mapper.run(gates, num_qubits, self.coupling_map)

--- a/src/qiskit_toqm/toqm_swap.py
+++ b/src/qiskit_toqm/toqm_swap.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 #
 # where min_duration is the length of the fastest non-zero duration
 # instruction on the target.
-NORMALIZE_SCALE = 1
+NORMALIZE_SCALE = 2
 
 
 class ToqmSwap(TransformationPass):

--- a/test/qiskit_toqm/test_toqm_swap.py
+++ b/test/qiskit_toqm/test_toqm_swap.py
@@ -45,15 +45,15 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
         )
 
         self.assertTrue(
-            all(x.latency == 1 for x in latencies if x.type == "x")
+            all(x.latency == 2 for x in latencies if x.type == "x")
         )
 
         self.assertTrue(
-            all(x.latency == 2 for x in latencies if x.type == "cx")
+            all(x.latency == 4 for x in latencies if x.type == "cx")
         )
 
         self.assertTrue(
-            all(x.latency == 6 for x in latencies if x.type == "swap")
+            all(x.latency == 12 for x in latencies if x.type == "swap")
         )
 
     def test_normalize_s(self):
@@ -75,15 +75,15 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
         )
 
         self.assertTrue(
-            all(x.latency == 1 for x in latencies if x.type == "x")
+            all(x.latency == 2 for x in latencies if x.type == "x")
         )
 
         self.assertTrue(
-            all(x.latency == 6 for x in latencies if x.type == "cx")
+            all(x.latency == 13 for x in latencies if x.type == "cx")
         )
 
         self.assertTrue(
-            all(x.latency == 14 for x in latencies if x.type == "swap")
+            all(x.latency == 28 for x in latencies if x.type == "swap")
         )
 
     def test_missing_swap_durations(self):
@@ -136,16 +136,16 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
         )
 
         self.assertTrue(
-            all(x.latency == 1 for x in latencies if x.type == "x")
+            all(x.latency == 2 for x in latencies if x.type == "x")
         )
 
         self.assertTrue(
-            all(x.latency == 10 for x in latencies if x.type == "cx")
+            all(x.latency == 20 for x in latencies if x.type == "cx")
         )
 
-        # round(152/10) = 15
+        # round(152*2/10) = 30
         self.assertTrue(
-            all(x.latency == 15 for x in latencies if x.type == "swap")
+            all(x.latency == 30 for x in latencies if x.type == "swap")
         )
 
     def test_normalize_close(self):
@@ -168,15 +168,15 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
         )
 
         self.assertTrue(
-            all(x.latency == 1 for x in latencies if x.type == "x")
+            all(x.latency == 2 for x in latencies if x.type == "x")
         )
 
-        # round(4/3) = 1
+        # round(4*2/3) = 3
         self.assertTrue(
-            all(x.latency == 1 for x in latencies if x.type == "cx")
+            all(x.latency == 3 for x in latencies if x.type == "cx")
         )
 
-        # round(5/3) = 2
+        # round(5*2/3) = 3
         self.assertTrue(
-            all(x.latency == 2 for x in latencies if x.type == "swap")
+            all(x.latency == 3 for x in latencies if x.type == "swap")
         )

--- a/test/qiskit_toqm/test_toqm_swap.py
+++ b/test/qiskit_toqm/test_toqm_swap.py
@@ -1,6 +1,6 @@
 import unittest
 
-from qiskit_toqm.toqm_swap import ToqmSwap
+from qiskit_toqm.toqm_swap import ToqmSwap, ToqmStrategyO1
 from qiskit.transpiler import CouplingMap, InstructionDurations, TranspilerError
 
 
@@ -22,6 +22,10 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
         self.durations_for_1q = durations_for_1q
         self.durations_for_2q = durations_for_2q
 
+        # Set optimality threshold to be greater than device size so we always
+        # use optimal mapping.
+        self.optimal_mapper = ToqmStrategyO1(self.coupling_map.size() + 1)
+
     def test_already_normalized(self):
         """
         Already normalized durations are used as cycle count without conversion.
@@ -33,7 +37,7 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
             *self.durations_for_2q("swap", 6)
         ], dt=1)
 
-        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False)
+        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False, strategy=self.optimal_mapper)
         latencies = list(swapper._build_latency_descriptions())
 
         self.assertTrue(
@@ -63,7 +67,7 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
             *self.durations_for_2q("swap", 4.977777777777778e-07, unit="s")
         ])
 
-        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False)
+        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False, strategy=self.optimal_mapper)
         latencies = list(swapper._build_latency_descriptions())
 
         self.assertTrue(
@@ -124,7 +128,7 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
             *self.durations_for_2q("swap", 152)
         ], dt=1)
 
-        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False)
+        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False, strategy=self.optimal_mapper)
         latencies = list(swapper._build_latency_descriptions())
 
         self.assertTrue(
@@ -156,7 +160,7 @@ class TestBuildLatencyDescriptions(unittest.TestCase):
             *self.durations_for_2q("swap", 5)
         ], dt=1)
 
-        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False)
+        swapper = ToqmSwap(self.coupling_map, durations, perform_layout=False, strategy=self.optimal_mapper)
         latencies = list(swapper._build_latency_descriptions())
 
         self.assertTrue(


### PR DESCRIPTION
Using Table latency seems to cause nontermination for some circuits. Currently,
it's thought that this only happens for heuristic mappers, but it's possible
the issue is present for optimal mappers as well. I just haven't found such a
case yet. Ultimately, it seems like there's a preexisting bug in TOQM that
gets exposed when we consider coupling-specific latencies.

Settings for optimization levels have also been tweaked so that mappings
terminate faster. These settings are based on some preliminary
benchmarks for QV256 circuits, and will be updated further once a more
comprehensive analysis of those results is performed.

The normalize factor has also been increase in ToqmSwap from 1 to 2 so
that Table durations have more resolution (i.e. gate durations that are
close should less often round to the same integer).