### PR TITLE
Refactor latency details out of ToqmSwap.

### DIFF
--- a/src/qiskit_toqm/__init__.py
+++ b/src/qiskit_toqm/__init__.py
@@ -1,2 +1,4 @@
+from .toqm_latency import latencies_from_target, latencies_from_simple
+from .toqm_strategy import ToqmHeuristicStrategy, ToqmOptimalStrategy
+from .toqm_strategy_presets import ToqmStrategyO0, ToqmStrategyO1, ToqmStrategyO2, ToqmStrategyO3
 from .toqm_swap import ToqmSwap
-from .toqm_strategy import ToqmStrategy, ToqmStrategyO0, ToqmStrategyO1, ToqmStrategyO2, ToqmStrategyO3

--- a/src/qiskit_toqm/toqm_latency.py
+++ b/src/qiskit_toqm/toqm_latency.py
@@ -70,7 +70,8 @@ def latencies_from_target(
     normalize_scale=2
 ):
     """
-    ToqmLatencyDescriptions initializer.
+    Generate a list of native ``LatencyDescription`` objects for
+    the specified target device.
 
     Args:
         coupling_map (CouplingMap): CouplingMap of the target backend.
@@ -131,6 +132,19 @@ def latencies_from_target(
 
 
 def latencies_from_simple(one_qubit_cycles, two_qubit_cycles, swap_cycles):
+    """
+    Generate a list of native ``LatencyDescription`` objects for
+    the specified hard-coded cycle counts.
+
+    The resulting latency descriptions describe a circuit in which
+    all 1Q, 2Q, and SWAP gates execute in the corresponding number
+    of cycles, irrespective of which qubits they execute on.
+
+    Args:
+        one_qubit_cycles (int): The number of cycles for all 1Q gates.
+        two_qubit_cycles (int): The number of cycles for all 2Q gates.
+        swap_cycles (int): The number of cycles for all swap gates.
+    """
     return [
         toqm.LatencyDescription(1, one_qubit_cycles),
         toqm.LatencyDescription(2, two_qubit_cycles),

--- a/src/qiskit_toqm/toqm_latency.py
+++ b/src/qiskit_toqm/toqm_latency.py
@@ -1,0 +1,138 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import qiskit
+from qiskit.transpiler import TranspilerError, InstructionDurations
+import qiskit_toqm.native as toqm
+
+from itertools import chain
+
+
+def _calc_swap_durations(coupling_map, instruction_durations, basis_gates, backend_properties):
+    """Calculates the durations of swap gates between each coupling on the target."""
+    # Filter for couplings that don't already have a native swap.
+    couplings = [
+        c for c in coupling_map.get_edges()
+        if ("swap", c) not in instruction_durations.duration_by_name_qubits
+    ]
+
+    if not couplings:
+        return
+
+    backend_aware = basis_gates is not None and backend_properties is not None
+    if not backend_aware:
+        raise TranspilerError(
+            "Both 'basis_gates' and 'backend_properties' must be specified unless"
+            "'instruction_durations' has durations for all swap gates."
+        )
+
+    def gen_swap_circuit(s, t):
+        # Generates a circuit with a single swap gate between src and tgt
+        c = qiskit.QuantumCircuit(coupling_map.size())
+        c.swap(s, t)
+        return c
+
+    # Batch transpile generated swap circuits
+    swap_circuits = qiskit.transpile(
+        [gen_swap_circuit(*pair) for pair in couplings],
+        basis_gates=basis_gates,
+        coupling_map=coupling_map,
+        backend_properties=backend_properties,
+        instruction_durations=instruction_durations,
+        optimization_level=0,
+        layout_method="trivial",
+        scheduling_method="asap"
+    )
+
+    for (src, tgt), qc in zip(couplings, swap_circuits):
+        if instruction_durations.dt is None and qc.unit == "dt":
+            # TODO: should be able to convert by looking up an op in both
+            raise TranspilerError("Incompatible units.")
+
+        duration = qc.qubit_duration(src, tgt)
+        yield src, tgt, duration
+
+
+def latencies_from_target(
+    coupling_map,
+    instruction_durations,
+    basis_gates=None,
+    backend_properties=None,
+    normalize_scale=2
+):
+    """
+    ToqmLatencyDescriptions initializer.
+
+    Args:
+        coupling_map (CouplingMap): CouplingMap of the target backend.
+        instruction_durations (InstructionDurations): Durations for gates
+            in the target's basis. Must include durations for all gates
+            that appear in input DAGs other than ``swap`` (for which
+            durations are calculated through decomposition if not supplied).
+        basis_gates (Optional[List[str]]): The list of basis gates for the
+            target. Must be specified unless ``instruction_durations``
+            contains durations for all swap gates.
+        backend_properties (Optional[BackendProperties]): The backend
+            properties of the target. Must be specified unless
+            ``instruction_durations`` contains durations for all swap gates.
+        normalize_scale (int): Multiple by this factor when converting
+            relative durations to cycle count. The conversion is:
+            cycles = ceil(duration * NORMALIZE_SCALE / min_duration)
+            where min_duration is the length of the fastest non-zero duration
+            instruction on the target.
+    """
+    unit = "dt" if instruction_durations.dt else "s"
+
+    swap_durations = list(_calc_swap_durations(coupling_map, instruction_durations, basis_gates, backend_properties))
+    default_op_durations = [
+        (op_name, instruction_durations.get(op_name, [], unit))
+        for op_name in instruction_durations.duration_by_name
+    ]
+    op_durations = [
+        (op_name, bits, instruction_durations.get(op_name, bits, unit))
+        for (op_name, bits) in instruction_durations.duration_by_name_qubits
+    ]
+
+    non_zero_durations = [d for d in chain(
+        (d for (_, d) in default_op_durations),
+        (d for (_, _, d) in op_durations),
+        (d for (_, _, d) in swap_durations)
+    ) if d > 0]
+
+    if not non_zero_durations:
+        raise TranspilerError("Durations must be specified for the target.")
+
+    min_duration = min(non_zero_durations)
+
+    def normalize(d):
+        return round(d * normalize_scale / min_duration)
+
+    # Yield latency descriptions with durations interpolated to cycles.
+    for op_name, duration in default_op_durations:
+        # We don't know if the instruction is for 1 or 2 qubits, so emit
+        # defaults for both.
+        yield toqm.LatencyDescription(1, op_name, normalize(duration))
+        yield toqm.LatencyDescription(2, op_name, normalize(duration))
+
+    for op_name, qubits, duration in op_durations:
+        yield toqm.LatencyDescription(op_name, *qubits, normalize(duration))
+
+    for src, tgt, duration in swap_durations:
+        yield toqm.LatencyDescription("swap", src, tgt, normalize(duration))
+
+
+def latencies_from_simple(one_qubit_cycles, two_qubit_cycles, swap_cycles):
+    return [
+        toqm.LatencyDescription(1, one_qubit_cycles),
+        toqm.LatencyDescription(2, two_qubit_cycles),
+        toqm.LatencyDescription(2, "swap", swap_cycles)
+    ]

--- a/src/qiskit_toqm/toqm_strategy.py
+++ b/src/qiskit_toqm/toqm_strategy.py
@@ -15,6 +15,25 @@ import qiskit_toqm.native as toqm
 
 class ToqmHeuristicStrategy:
     def __init__(self, latency_descriptions, top_k, queue_target, queue_max, retain_popped=1):
+        """
+        Constructs a TOQM strategy that aims to minimize overall circuit duration.
+        The priority queue used in the A* is configured to drop the worst nodes
+        whenever it reaches the queue size limit. Node expansion is also limited
+        to exploring the best ``K`` children.
+
+        Args:
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
+            top_k (int): The maximum number of best child nodes that can be pushed to the
+            queue during expansion of any given node.
+            queue_target (int): When the priority queue reaches capacity, nodes are dropped
+            until the size reaches this value.
+            queue_max (int): The priority queue capacity.
+            retain_popped (int): Final nodes to retain.
+
+        Raises:
+            RuntimeError: No routing was found.
+        """
         # The following defaults are based on:
         # https://github.com/time-optimal-qmapper/TOQM/blob/main/code/README.txt
         self.mapper = toqm.ToqmMapper(
@@ -29,14 +48,14 @@ class ToqmHeuristicStrategy:
 
         self.mapper.setRetainPopped(retain_popped)
 
-    def __call__(self, coupling_map, gates, num_qubits):
+    def __call__(self, gates, num_qubits, coupling_map):
         """
         Run native ToqmMapper and return the native result.
 
         Args:
-            coupling_map (toqm.CouplingMap): The coupling map of the target.
             gates (List[toqm.GateOp]): The topologically ordered list of gate operations.
             num_qubits (int): The number of virtual qubits used in the circuit.
+            coupling_map (toqm.CouplingMap): The coupling map of the target.
 
         Returns:
             toqm.ToqmResult: The native result.
@@ -51,8 +70,8 @@ class ToqmOptimalStrategy:
         in terms of overall circuit duration.
 
         Args:
-            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions for all target gates,
-            including swaps.
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
             perform_layout (Boolean): If true, permutes the initial layout rather than
             inserting swap gates at the start of the circuit.
             no_swaps (Boolean): If true, attempts to find a routing without inserting swaps.
@@ -72,14 +91,14 @@ class ToqmOptimalStrategy:
             -1 if perform_layout else 0
         )
 
-    def __call__(self, coupling_map, gates, num_qubits):
+    def __call__(self, gates, num_qubits, coupling_map):
         """
         Run native ToqmMapper and return the native result.
 
         Args:
-            coupling_map (toqm.CouplingMap): The coupling map of the target.
             gates (List[toqm.GateOp]): The topologically ordered list of gate operations.
             num_qubits (int): The number of virtual qubits used in the circuit.
+            coupling_map (toqm.CouplingMap): The coupling map of the target.
 
         Returns:
             toqm.ToqmResult: The native result.

--- a/src/qiskit_toqm/toqm_strategy_presets.py
+++ b/src/qiskit_toqm/toqm_strategy_presets.py
@@ -1,0 +1,116 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from qiskit_toqm import ToqmHeuristicStrategy, ToqmOptimalStrategy
+
+# NOTE: currently, the heuristic mappers use the hard-coded latencies of 1, 2 and 6
+# for 1Q, 2Q and SWAP gates, respectively. This is because when gate-specific latencies
+# are used with heuristic components, the run sometimes never terminates.
+# This is tracked here: https://github.com/qiskit-toqm/libtoqm/issues/15
+from qiskit_toqm import latencies_from_simple
+
+
+class ToqmStrategyO0:
+    def __init__(self, latency_descriptions):
+        self.heuristic_strategy = ToqmHeuristicStrategy(
+            latency_descriptions,
+            top_k=1,
+            queue_target=3000,
+            queue_max=5000
+        )
+
+    def __call__(self, coupling_map, gates, num_qubits):
+        return self.heuristic_strategy(coupling_map, gates, num_qubits)
+
+
+class ToqmStrategyO1:
+    def __init__(self, latency_descriptions):
+        # https://github.com/qiskit-toqm/libtoqm/issues/15
+        latency_descriptions = latencies_from_simple(1, 2, 6)
+
+        self.optimal_strategy = ToqmOptimalStrategy(
+            latency_descriptions
+        )
+
+        self.heuristic_strategy = ToqmHeuristicStrategy(
+            latency_descriptions,
+            top_k=5,
+            queue_target=400,
+            queue_max=800
+        )
+
+    def __call__(self, coupling_map, gates, num_qubits):
+        if coupling_map.numPhysicalQubits < 6:
+            strategy = self.optimal_strategy
+        else:
+            strategy = self.heuristic_strategy
+
+        return strategy(coupling_map, gates, num_qubits)
+
+
+class ToqmStrategyO2:
+    def __init__(self, latency_descriptions):
+        # https://github.com/qiskit-toqm/libtoqm/issues/15
+        latency_descriptions = latencies_from_simple(1, 2, 6)
+
+        self.optimal_strategy = ToqmOptimalStrategy(
+            latency_descriptions
+        )
+
+        self.heuristic_strategy = ToqmHeuristicStrategy(
+            latency_descriptions,
+            top_k=11,
+            queue_target=400,
+            queue_max=100
+        )
+
+    def __call__(self, coupling_map, gates, num_qubits):
+        if coupling_map.numPhysicalQubits < 6:
+            strategy = self.optimal_strategy
+        else:
+            strategy = self.heuristic_strategy
+
+        return strategy(coupling_map, gates, num_qubits)
+
+
+class ToqmStrategyO3:
+    def __init__(self, latency_descriptions):
+        # https://github.com/qiskit-toqm/libtoqm/issues/15
+        latency_descriptions = latencies_from_simple(1, 2, 6)
+
+        self.optimal_strategy = ToqmOptimalStrategy(
+            latency_descriptions
+        )
+
+        self.optimal_strategy_no_swaps = ToqmOptimalStrategy(
+            latency_descriptions,
+            no_swaps=True
+        )
+
+        self.heuristic_strategy = ToqmHeuristicStrategy(
+            latency_descriptions,
+            top_k=3,
+            queue_target=3600,
+            queue_max=4800
+        )
+
+    def __call__(self, coupling_map, gates, num_qubits):
+        if coupling_map.numPhysicalQubits < 6:
+            # try no swaps first
+            try:
+                return self.optimal_strategy_no_swaps(coupling_map, gates, num_qubits)
+            except RuntimeError:
+                strategy = self.optimal_strategy
+        else:
+            strategy = self.heuristic_strategy
+
+        return strategy(coupling_map, gates, num_qubits)

--- a/src/qiskit_toqm/toqm_strategy_presets.py
+++ b/src/qiskit_toqm/toqm_strategy_presets.py
@@ -21,6 +21,13 @@ from qiskit_toqm import latencies_from_simple
 
 class ToqmStrategyO0:
     def __init__(self, latency_descriptions):
+        """
+        Constructs a TOQM strategy that executes as fast as possible.
+
+        Args:
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
+        """
         self.heuristic_strategy = ToqmHeuristicStrategy(
             latency_descriptions,
             top_k=1,
@@ -28,12 +35,21 @@ class ToqmStrategyO0:
             queue_max=5000
         )
 
-    def __call__(self, coupling_map, gates, num_qubits):
-        return self.heuristic_strategy(coupling_map, gates, num_qubits)
+    def __call__(self, gates, num_qubits, coupling_map):
+        return self.heuristic_strategy(gates, num_qubits, coupling_map)
 
 
 class ToqmStrategyO1:
     def __init__(self, latency_descriptions):
+        """
+        Constructs a TOQM strategy that should produce a circuit with
+        a shorter duration than lower optimization levels, but that
+        takes longer to run.
+
+        Args:
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
+        """
         # https://github.com/qiskit-toqm/libtoqm/issues/15
         latency_descriptions = latencies_from_simple(1, 2, 6)
 
@@ -48,17 +64,26 @@ class ToqmStrategyO1:
             queue_max=800
         )
 
-    def __call__(self, coupling_map, gates, num_qubits):
+    def __call__(self, gates, num_qubits, coupling_map):
         if coupling_map.numPhysicalQubits < 6:
             strategy = self.optimal_strategy
         else:
             strategy = self.heuristic_strategy
 
-        return strategy(coupling_map, gates, num_qubits)
+        return strategy(gates, num_qubits, coupling_map)
 
 
 class ToqmStrategyO2:
     def __init__(self, latency_descriptions):
+        """
+        Constructs a TOQM strategy that should produce a circuit with
+        a shorter duration than lower optimization levels, but that
+        takes longer to run.
+
+        Args:
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
+        """
         # https://github.com/qiskit-toqm/libtoqm/issues/15
         latency_descriptions = latencies_from_simple(1, 2, 6)
 
@@ -73,17 +98,26 @@ class ToqmStrategyO2:
             queue_max=100
         )
 
-    def __call__(self, coupling_map, gates, num_qubits):
+    def __call__(self, gates, num_qubits, coupling_map):
         if coupling_map.numPhysicalQubits < 6:
             strategy = self.optimal_strategy
         else:
             strategy = self.heuristic_strategy
 
-        return strategy(coupling_map, gates, num_qubits)
+        return strategy(gates, num_qubits, coupling_map)
 
 
 class ToqmStrategyO3:
     def __init__(self, latency_descriptions):
+        """
+        Constructs a TOQM strategy that should produce a circuit with
+        a shorter duration than lower optimization levels, but that
+        takes MUCH longer to run.
+
+        Args:
+            latency_descriptions (List[toqm.LatencyDescription]): The latency descriptions
+            for all gates that will appear in the circuit, including swaps.
+        """
         # https://github.com/qiskit-toqm/libtoqm/issues/15
         latency_descriptions = latencies_from_simple(1, 2, 6)
 
@@ -103,14 +137,14 @@ class ToqmStrategyO3:
             queue_max=4800
         )
 
-    def __call__(self, coupling_map, gates, num_qubits):
+    def __call__(self, gates, num_qubits, coupling_map):
         if coupling_map.numPhysicalQubits < 6:
             # try no swaps first
             try:
-                return self.optimal_strategy_no_swaps(coupling_map, gates, num_qubits)
+                return self.optimal_strategy_no_swaps(gates, num_qubits, coupling_map)
             except RuntimeError:
                 strategy = self.optimal_strategy
         else:
             strategy = self.heuristic_strategy
 
-        return strategy(coupling_map, gates, num_qubits)
+        return strategy(gates, num_qubits, coupling_map)

--- a/src/qiskit_toqm/toqm_swap.py
+++ b/src/qiskit_toqm/toqm_swap.py
@@ -43,7 +43,7 @@ class ToqmSwap(TransformationPass):
 
         Args:
             coupling_map (CouplingMap): CouplingMap of the target backend.
-            strategy (typing.Callable[[toqm.CouplingMap, List[toqm.GateOp], int], toqm.ToqmResult]):
+            strategy (typing.Callable[[List[toqm.GateOp], int, toqm.CouplingMap], toqm.ToqmResult]):
                 A callable responsible for running the native ``ToqmMapper`` and
                 returning a native ``ToqmResult``.
         """
@@ -103,7 +103,7 @@ class ToqmSwap(TransformationPass):
         edges = {e for e in self.coupling_map.get_edges()}
         couplings = toqm.CouplingMap(self.coupling_map.size(), edges)
 
-        self.toqm_result = self.toqm_strategy(couplings, gate_ops, dag.num_qubits())
+        self.toqm_result = self.toqm_strategy(gate_ops, dag.num_qubits(), couplings)
 
         # Preserve input DAG's name, regs, wire_map, etc. but replace the graph.
         mapped_dag = dag.copy_empty_like()

--- a/src/qiskit_toqm/toqm_swap.py
+++ b/src/qiskit_toqm/toqm_swap.py
@@ -11,32 +11,15 @@
 # that they have been altered from the originals.
 import logging
 
-import qiskit
 import qiskit_toqm.native as toqm
 
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import InstructionDurations
 
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
-from itertools import chain
-
-from .toqm_strategy import ToqmStrategy, ToqmStrategyO1
-
 logger = logging.getLogger(__name__)
-
-
-# Multiply by this factor when converting relative durations to cycle
-# count.
-#
-# The conversion is:
-#   cycles = ceil(duration * NORMALIZE_SCALE / min_duration)
-#
-# where min_duration is the length of the fastest non-zero duration
-# instruction on the target.
-NORMALIZE_SCALE = 2
 
 
 class ToqmSwap(TransformationPass):
@@ -54,28 +37,15 @@ class ToqmSwap(TransformationPass):
     def __init__(
             self,
             coupling_map,
-            instruction_durations,
-            strategy=None,
-            basis_gates=None,
-            backend_properties=None):
+            strategy):
         """
         ToqmSwap initializer.
 
         Args:
             coupling_map (CouplingMap): CouplingMap of the target backend.
-            instruction_durations (InstructionDurations): Durations for gates
-                in the target's basis. Must include durations for all gates
-                that appear in input DAGs other than ``swap`` (for which
-                durations are calculated through decomposition if not supplied).
-            strategy (Optional[ToqmStrategy]):
-                The strategy to use when invoking the native ToqmMapper.
-                Defaults to ``ToqmStrategyO1()``.
-            basis_gates (Optional[List[str]]): The list of basis gates for the
-                target. Must be specified unless ``instruction_durations``
-                contains durations for all swap gates.
-            backend_properties (Optional[BackendProperties]): The backend
-                properties of the target. Must be specified unless
-                ``instruction_durations`` contains durations for all swap gates.
+            strategy (typing.Callable[[toqm.CouplingMap, List[toqm.GateOp], int], toqm.ToqmResult]):
+                A callable responsible for running the native ``ToqmMapper`` and
+                returning a native ``ToqmResult``.
         """
         super().__init__()
 
@@ -89,105 +59,8 @@ class ToqmSwap(TransformationPass):
             raise TranspilerError("ToqmSwap currently supports a max of 127 qubits.")
 
         self.coupling_map = coupling_map
-        self.instruction_durations = instruction_durations
-        self.basis_gates = basis_gates
-        self.backend_properties = backend_properties
-        self.toqm_strategy = strategy or ToqmStrategyO1()
+        self.toqm_strategy = strategy
         self.toqm_result = None
-
-        edges = {e for e in self.coupling_map.get_edges()}
-        couplings = toqm.CouplingMap(self.coupling_map.size(), edges)
-        latency_descriptions = list(self._build_latency_descriptions())
-
-        self.toqm_strategy.on_pass_init(couplings, latency_descriptions)
-
-    def _calc_swap_durations(self):
-        """Calculates the durations of swap gates between each coupling on the target."""
-        # Filter for couplings that don't already have a native swap.
-        couplings = [
-            c for c in self.coupling_map.get_edges()
-            if ("swap", c) not in self.instruction_durations.duration_by_name_qubits
-        ]
-
-        if not couplings:
-            return
-
-        backend_aware = self.basis_gates is not None and self.backend_properties is not None
-        if not backend_aware:
-            raise TranspilerError(
-                "Both 'basis_gates' and 'backend_properties' must be specified unless"
-                "'instruction_durations' has durations for all swap gates."
-            )
-
-        def gen_swap_circuit(s, t):
-            # Generates a circuit with a single swap gate between src and tgt
-            c = qiskit.QuantumCircuit(self.coupling_map.size())
-            c.swap(s, t)
-            return c
-
-        # Batch transpile generated swap circuits
-        swap_circuits = qiskit.transpile(
-            [gen_swap_circuit(*pair) for pair in couplings],
-            basis_gates=self.basis_gates,
-            coupling_map=self.coupling_map,
-            backend_properties=self.backend_properties,
-            instruction_durations=self.instruction_durations,
-            optimization_level=0,
-            layout_method="trivial",
-            scheduling_method="asap"
-        )
-
-        for (src, tgt), qc in zip(couplings, swap_circuits):
-            if self.instruction_durations.dt is None and qc.unit == "dt":
-                # TODO: should be able to convert by looking up an op in both
-                raise TranspilerError("Incompatible units.")
-
-            duration = (
-                    max(qc.qubit_stop_time(src), qc.qubit_stop_time(tgt))
-                    - min(qc.qubit_start_time(src), qc.qubit_start_time(tgt))
-            )
-
-            yield src, tgt, duration
-
-    def _build_latency_descriptions(self):
-        unit = "dt" if self.instruction_durations.dt else "s"
-
-        swap_durations = list(self._calc_swap_durations())
-        default_op_durations = [
-            (op_name, self.instruction_durations.get(op_name, [], unit))
-            for op_name in self.instruction_durations.duration_by_name
-        ]
-        op_durations = [
-            (op_name, bits, self.instruction_durations.get(op_name, bits, unit))
-            for (op_name, bits) in self.instruction_durations.duration_by_name_qubits
-        ]
-
-        non_zero_durations = [d for d in chain(
-            (d for (_, d) in default_op_durations),
-            (d for (_, _, d) in op_durations),
-            (d for (_, _, d) in swap_durations)
-        ) if d > 0]
-
-        if not non_zero_durations:
-            raise TranspilerError("Durations must be specified for the target.")
-
-        min_duration = min(non_zero_durations)
-
-        def normalize(d):
-            return round(d * NORMALIZE_SCALE / min_duration)
-
-        # Yield latency descriptions with durations interpolated to cycles.
-        for op_name, duration in default_op_durations:
-            # We don't know if the instruction is for 1 or 2 qubits, so emit
-            # defaults for both.
-            yield toqm.LatencyDescription(1, op_name, normalize(duration))
-            yield toqm.LatencyDescription(2, op_name, normalize(duration))
-
-        for op_name, qubits, duration in op_durations:
-            yield toqm.LatencyDescription(op_name, *qubits, normalize(duration))
-
-        for src, tgt, duration in swap_durations:
-            yield toqm.LatencyDescription("swap", src, tgt, normalize(duration))
 
     def run(self, dag: DAGCircuit):
         """Run the ToqmSwap pass on `dag`.
@@ -201,12 +74,6 @@ class ToqmSwap(TransformationPass):
         """
         if self.coupling_map is None:
             raise TranspilerError("TOQM swap not properly initialized.")
-
-        if self.instruction_durations is None or (
-                not self.instruction_durations.duration_by_name_qubits
-                and not self.instruction_durations.duration_by_name
-        ):
-            raise TranspilerError("Instruction durations must be specified for this pass!")
 
         if len(dag.qregs) != 1 or dag.qregs.get("q", None) is None:
             raise TranspilerError("TOQM swap runs on physical circuits only.")
@@ -233,7 +100,10 @@ class ToqmSwap(TransformationPass):
                                           f"Bad gate: {node.op.name} {node.qargs}")
 
         gate_ops = list(gates())
-        self.toqm_result = self.toqm_strategy.run(gate_ops, dag.num_qubits())
+        edges = {e for e in self.coupling_map.get_edges()}
+        couplings = toqm.CouplingMap(self.coupling_map.size(), edges)
+
+        self.toqm_result = self.toqm_strategy(couplings, gate_ops, dag.num_qubits())
 
         # Preserve input DAG's name, regs, wire_map, etc. but replace the graph.
         mapped_dag = dag.copy_empty_like()

--- a/test/qiskit_toqm/test_toqm_latency.py
+++ b/test/qiskit_toqm/test_toqm_latency.py
@@ -1,6 +1,5 @@
 import unittest
 
-from qiskit_toqm.toqm_swap import ToqmSwap
 from qiskit_toqm.toqm_latency import latencies_from_target
 from qiskit.transpiler import CouplingMap, InstructionDurations, TranspilerError
 


### PR DESCRIPTION
## Description
Target-based latency descriptions were previously computed
in ToqmSwap, but this wasn't the best design since it's
entirely possible for a mapper strategy to work without
target durations, hence they would be computed needlessly.

This factoring removes a level of indirection where ToqmSwap
would need to pass the strategy the computed latency
descriptions via ToqmStrategy.on_pass_init, which is now
no longer needed. Consequently, the ToqmStrategy class
hierarchy was simplified. Now, what was a ToqmStrategy is
simply a callable. There are two helper callables provided
out of the box, ToqmOptimisticStrategy and
ToqmHeuristicStrategy which can be used to quickly whip up
a strategy with easy customization via their parameters.

All helper callable take a latency_descriptions parameter
the value of which can be generated either from a Qiskit
Terra target (i.e. coupling map, instruction latencies, etc.)
or from simple hard-coded cycle values via convenience
functions latencies_from_target and latencies_from_simple,
respectively.

## Usage
### Create heuristic `ToqmSwap` pass from Terra target
```py
from qiskit_toqm import ToqmSwap, ToqmHeuristicStrategy, latencies_from_target

latencies = latencies_from_target(coupling_map, instruction_durations, basis_gates, backend_properties)
strategy = ToqmHeuristicStrategy(latencies, top_k=10, queue_target=1000, queue_max=2000)
swap = ToqmSwap(coupling_map, strategy)
```

### Create optimal `ToqmSwap` pass from hard-coded cycles
```py
from qiskit_toqm import ToqmSwap, ToqmOptimalStrategy, latencies_from_simple

latencies = latencies_from_simple(one_qubit_cycles=1, two_qubit_cycles=2, swap_cycles=6)
strategy = ToqmOptimalStrategy(latencies, perform_layout=False)
swap = ToqmSwap(coupling_map, strategy)
```