### PR TITLE
Disable wheel testing for ppc64le and s390x.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -123,6 +123,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.4.0
       env:
         CIBW_ARCHS_LINUX: ppc64le
+        CIBW_TEST_SKIP: "cp*"
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash
@@ -154,7 +155,8 @@ jobs:
         platforms: all
     - uses: pypa/cibuildwheel@v2.4.0
       env:
-        CIBW_ARCHS_LINUX: ppc64le
+        CIBW_ARCHS_LINUX: s390x
+        CIBW_TEST_SKIP: "cp*"
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash


### PR DESCRIPTION
These architectures don't have many of the Python dep packages available, and they take too long to build in QEMU. We do this in Terra as well.