### PR TITLE
Update for Qiskit 1.0

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   QISKIT_PARALLEL: false
-  CIBW_SKIP: 'pp37-*'
+  CIBW_SKIP: '*p37-*'
 
 jobs:
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   QISKIT_PARALLEL: false
-  CIBW_SKIP: 'cp37-*'
+  CIBW_SKIP: 'pp37-*'
 
 jobs:
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   QISKIT_PARALLEL: false
+  CIBW_SKIP: 'cp37-*'
 
 jobs:
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   QISKIT_PARALLEL: false
-  CIBW_SKIP: '*p37-*'
 
 jobs:
   build_sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 test-requires = ["qiskit>=1.0"]
 test-skip = "cp310-win32 cp310-manylinux_i686"
-skip = "pp* cp36-* *musllinux*"
+skip = "pp* cp36-* cp37-* *musllinux*"
 test-command = "pytest {project}/test"
 test-extras = ["test"]
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ profile = "black"
 environment-pass = ["QISKIT_PARALLEL"]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-test-requires = ["qiskit-terra>=0.22"]
+test-requires = ["qiskit>=1.0"]
 test-skip = "cp310-win32 cp310-manylinux_i686"
 skip = "pp* cp36-* *musllinux*"
 test-command = "pytest {project}/test"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit-terra>=0.22.0
+qiskit>=1.0
 numpy>=1.17

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     cmake_install_dir="src/qiskit_toqm/native",
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    extras_require={"test": ["pytest"]},
+    extras_require={"test": ["pytest", "qiskit-ibm-runtime>=0.20.0"]},
     python_requires=">=3.7",
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-toqm/qiskit-toqm/issues",

--- a/test/qiskit_toqm/test_toqm_latency.py
+++ b/test/qiskit_toqm/test_toqm_latency.py
@@ -2,7 +2,7 @@ import unittest
 
 from qiskit_toqm.toqm_latency import latencies_from_target
 from qiskit.transpiler import CouplingMap, InstructionDurations, TranspilerError
-from qiskit.providers.fake_provider import FakeMontrealV2
+from qiskit_ibm_runtime.fake_provider import FakeMontrealV2
 
 
 class TestBuildLatencyDescriptions(unittest.TestCase):


### PR DESCRIPTION
Removes the `qiskit.providers` import to make this project compatible with Qiskit 1.0.

I can't work out how to get CI to pass.